### PR TITLE
Feature/fix golang docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest as builder
+FROM golang:1.16 as builder
 
 # Ensure go build env is correct
 ENV GOOS linux

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ builddist:
 	goreleaser release --snapshot --skip-publish
 
 test:
-	go test -cover
+	go test ./... -cover


### PR DESCRIPTION
### Changed

- Use Go v1.16 to match go.mod
- Run all the tests with `make test`