### PR TITLE
fix GetInstanceTypeForAsg to work with Launch Template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Ensure this version tracks with go.mod and codeship/Dockerfile
 FROM golang:1.19 as builder
 
 # Ensure go build env is correct

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /src
 RUN go get ./...
 RUN go build -ldflags="-s -w" -o awsops
 
-FROM alpine:latest
+FROM alpine:3
 RUN apk update && \
     apk add ca-certificates && \
     rm -rf /var/cache/apk/*

--- a/codeship/Dockerfile
+++ b/codeship/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:latest
+# Ensure this version tracks with go.mod and /Dockerfile
+FROM golang:1.19
 
 RUN apt-get update && apt-get install -y awscli
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/silinternational/awsops
 
+// Ensure this version tracks with /Dockerfile and codeship/Dockerfile
 go 1.19
 
 require (


### PR DESCRIPTION
### Fixed
- Fix nil pointer dereference panic by improving `GetInstanceTypeForAsg` to use Launch Templates in addition to Launch Configurations.