### PR TITLE
ITSE-68 -- take wasted resources into account

### DIFF
--- a/cmd/ecsRightSizeCluster.go
+++ b/cmd/ecsRightSizeCluster.go
@@ -15,8 +15,11 @@
 package cmd
 
 import (
-	"github.com/silinternational/awsops/lib"
+	"os"
+
 	"github.com/spf13/cobra"
+
+	"github.com/silinternational/awsops/lib"
 )
 
 var atLeastServiceDesiredCount bool
@@ -33,7 +36,10 @@ support running all tasks with as few servers as is needed.
 This function may scale a cluster up or down depending on services.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		initAwsSess()
-		lib.RightSizeAsgForEcsCluster(AwsSess, cluster, atLeastServiceDesiredCount)
+		err := lib.RightSizeAsgForEcsCluster(AwsSess, cluster, atLeastServiceDesiredCount)
+		if err != nil {
+			os.Exit(1)
+		}
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,11 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
+	github.com/stretchr/testify v1.8.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -18,6 +20,7 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.6 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/afero v1.9.4 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/lib/asg.go
+++ b/lib/asg.go
@@ -159,6 +159,18 @@ func HowManyServersNeededForAsg(serverType string, resourcesNeeded ResourceSizes
 		os.Exit(1)
 	}
 
+	if resourcesNeeded.LargestMemory > instanceSpecs.MemoryMb {
+		fmt.Printf("Configured instance type is not large enough. Available memory is %d, but largest task needs %d",
+			instanceSpecs.MemoryMb, resourcesNeeded.LargestMemory)
+		os.Exit(1)
+	}
+
+	if resourcesNeeded.LargestCPU > instanceSpecs.CPUUnits {
+		fmt.Printf("Configured instance type is not large enough. Available CPU is %d, but largest task needs %d",
+			instanceSpecs.CPUUnits, resourcesNeeded.LargestCPU)
+		os.Exit(1)
+	}
+
 	// Some memory in each instance cannot be used because no container can be placed in the last portion available.
 	// This assumes the best-case container placement.
 	usableMemory := max(1, instanceSpecs.MemoryMb-resourcesNeeded.SmallestMemory)

--- a/lib/asg_test.go
+++ b/lib/asg_test.go
@@ -42,7 +42,11 @@ func TestHowManyServersNeededFor(t *testing.T) {
 	}
 
 	for _, i := range tests {
-		results := HowManyServersNeededForAsg(i.ServerType, i.MemNeeded, i.CPUNeeded)
+		resourceSizes := ResourceSizes{
+			TotalCPU:    i.CPUNeeded,
+			TotalMemory: i.MemNeeded,
+		}
+		results := HowManyServersNeededForAsg(i.ServerType, resourceSizes)
 		if results != i.ExpectedNum {
 			t.Errorf("Did not get back expected number of %s servers needed for %v mem and %v cpu, expected %v, got %v",
 				i.ServerType, i.MemNeeded, i.CPUNeeded, i.ExpectedNum, results)

--- a/lib/asg_test.go
+++ b/lib/asg_test.go
@@ -6,6 +6,8 @@ func TestHowManyServersNeededFor(t *testing.T) {
 	tests := []struct {
 		MemNeeded   int64
 		CPUNeeded   int64
+		SmallestMem int64
+		SmallestCPU int64
 		ServerType  string
 		ExpectedNum int64
 	}{
@@ -39,12 +41,28 @@ func TestHowManyServersNeededFor(t *testing.T) {
 			ServerType:  "t2.micro",
 			ExpectedNum: 3,
 		},
+		{
+			MemNeeded:   886,
+			CPUNeeded:   1,
+			SmallestMem: 100,
+			ServerType:  "t2.micro",
+			ExpectedNum: 2, // 1024 - 39 - 100 = 885 MB available per instance
+		},
+		{
+			MemNeeded:   1,
+			CPUNeeded:   925,
+			SmallestCPU: 100,
+			ServerType:  "t2.micro",
+			ExpectedNum: 2, // 1024 - 100 = 924 CPU available per instance
+		},
 	}
 
 	for _, i := range tests {
 		resourceSizes := ResourceSizes{
-			TotalCPU:    i.CPUNeeded,
-			TotalMemory: i.MemNeeded,
+			TotalCPU:       i.CPUNeeded,
+			TotalMemory:    i.MemNeeded,
+			SmallestCPU:    i.SmallestCPU,
+			SmallestMemory: i.SmallestMem,
 		}
 		results := HowManyServersNeededForAsg(i.ServerType, resourceSizes)
 		if results != i.ExpectedNum {

--- a/lib/ec2.go
+++ b/lib/ec2.go
@@ -40,4 +40,32 @@ var InstanceTypes = map[string]InstanceType{
 		CPUUnits: 8 * SingleCPUUnits,
 		MemoryMb: 32*MbInGb - AgentSize,
 	},
+	"t3.nano": {
+		CPUUnits: 2 * SingleCPUUnits,
+		MemoryMb: 512 - AgentSize,
+	},
+	"t3.micro": {
+		CPUUnits: 2 * SingleCPUUnits,
+		MemoryMb: 1*MbInGb - AgentSize,
+	},
+	"t3.small": {
+		CPUUnits: 2 * SingleCPUUnits,
+		MemoryMb: 2*MbInGb - AgentSize,
+	},
+	"t3.medium": {
+		CPUUnits: 2 * SingleCPUUnits,
+		MemoryMb: 4*MbInGb - AgentSize,
+	},
+	"t3.large": {
+		CPUUnits: 2 * SingleCPUUnits,
+		MemoryMb: 8*MbInGb - AgentSize,
+	},
+	"t3.xlarge": {
+		CPUUnits: 4 * SingleCPUUnits,
+		MemoryMb: 16*MbInGb - AgentSize,
+	},
+	"t3.2xlarge": {
+		CPUUnits: 8 * SingleCPUUnits,
+		MemoryMb: 32*MbInGb - AgentSize,
+	},
 }

--- a/lib/ec2.go
+++ b/lib/ec2.go
@@ -5,36 +5,39 @@ type InstanceType struct {
 	CPUUnits int64
 }
 
-var SingleCPUUnits int64 = 1024
-var MbInGb int64 = 985 // only 985 out of 1024 is available for use due to ECS agent
+const (
+	SingleCPUUnits int64 = 1024
+	MbInGb         int64 = 1024
+	AgentSize      int64 = 39 // memory consumed by the ECS agent
+)
 
 var InstanceTypes = map[string]InstanceType{
 	"t2.nano": {
 		CPUUnits: 1 * SingleCPUUnits,
-		MemoryMb: 512,
+		MemoryMb: 512 - AgentSize,
 	},
 	"t2.micro": {
 		CPUUnits: 1 * SingleCPUUnits,
-		MemoryMb: 1 * MbInGb,
+		MemoryMb: 1*MbInGb - AgentSize,
 	},
 	"t2.small": {
 		CPUUnits: 1 * SingleCPUUnits,
-		MemoryMb: 2 * MbInGb,
+		MemoryMb: 2*MbInGb - AgentSize,
 	},
 	"t2.medium": {
 		CPUUnits: 2 * SingleCPUUnits,
-		MemoryMb: 4 * MbInGb,
+		MemoryMb: 4*MbInGb - AgentSize,
 	},
 	"t2.large": {
 		CPUUnits: 2 * SingleCPUUnits,
-		MemoryMb: 8 * MbInGb,
+		MemoryMb: 8*MbInGb - AgentSize,
 	},
 	"t2.xlarge": {
 		CPUUnits: 4 * SingleCPUUnits,
-		MemoryMb: 16 * MbInGb,
+		MemoryMb: 16*MbInGb - AgentSize,
 	},
 	"t2.2xlarge": {
 		CPUUnits: 8 * SingleCPUUnits,
-		MemoryMb: 32 * MbInGb,
+		MemoryMb: 32*MbInGb - AgentSize,
 	},
 }

--- a/lib/ec2.go
+++ b/lib/ec2.go
@@ -14,7 +14,7 @@ const (
 var InstanceTypes = map[string]InstanceType{
 	"t2.nano": {
 		CPUUnits: 1 * SingleCPUUnits,
-		MemoryMb: 512 - AgentSize,
+		MemoryMb: MbInGb/2 - AgentSize,
 	},
 	"t2.micro": {
 		CPUUnits: 1 * SingleCPUUnits,
@@ -42,7 +42,7 @@ var InstanceTypes = map[string]InstanceType{
 	},
 	"t3.nano": {
 		CPUUnits: 2 * SingleCPUUnits,
-		MemoryMb: 512 - AgentSize,
+		MemoryMb: MbInGb/2 - AgentSize,
 	},
 	"t3.micro": {
 		CPUUnits: 2 * SingleCPUUnits,

--- a/lib/ecs.go
+++ b/lib/ecs.go
@@ -182,10 +182,9 @@ func RightSizeAsgForEcsCluster(awsSess *session.Session, cluster string, atLeast
 
 	ecsServices := ListServicesForEcsCluster(awsSess, cluster)
 	resourcesNeeded := GetMemoryCpuNeededForEcsServices(awsSess, ecsServices)
-	memoryNeeded, cpuNeeded := resourcesNeeded.TotalMemory, resourcesNeeded.TotalCPU
-	fmt.Printf("Memory needed for all services with desired count > 0: %v, CPU needed: %v\n", memoryNeeded, cpuNeeded)
+	fmt.Printf("Resources needed for all services with desired count > 0: %+v\n", resourcesNeeded)
 
-	serversNeeded := HowManyServersNeededForAsg(instanceType, memoryNeeded, cpuNeeded)
+	serversNeeded := HowManyServersNeededForAsg(instanceType, resourcesNeeded)
 	fmt.Printf("ASG should have %v servers to fit all tasks\n", serversNeeded)
 
 	// If an ECS service has a desired count > serversNeeded, and atLeastServiceDesiredCount is true, set serversNeeded to

--- a/lib/ecs.go
+++ b/lib/ecs.go
@@ -189,8 +189,8 @@ func RightSizeAsgForEcsCluster(awsSess *session.Session, cluster string, atLeast
 
 	// If an ECS service has a desired count > serversNeeded, and atLeastServiceDesiredCount is true, set serversNeeded to
 	// largest ecs service desired count value
-	largestDesiredCount := GetLargestDesiredCountFromEcsServices(ecsServices)
 	if atLeastServiceDesiredCount {
+		largestDesiredCount := GetLargestDesiredCountFromEcsServices(ecsServices)
 		serversNeeded = max(largestDesiredCount, serversNeeded)
 	}
 

--- a/lib/ecs_test.go
+++ b/lib/ecs_test.go
@@ -1,0 +1,17 @@
+package lib
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_max(t *testing.T) {
+	require.Equal(t, max(2, 1), int64(2))
+	require.Equal(t, max(1, 2), int64(2))
+	require.Equal(t, max(-2, 1), int64(1))
+	require.Equal(t, max(1, -2), int64(1))
+	require.Equal(t, max(math.MaxInt, -2), int64(math.MaxInt))
+	require.Equal(t, max(math.MinInt, -2), int64(-2))
+}

--- a/lib/ecs_test.go
+++ b/lib/ecs_test.go
@@ -15,3 +15,12 @@ func Test_max(t *testing.T) {
 	require.Equal(t, max(math.MaxInt, -2), int64(math.MaxInt))
 	require.Equal(t, max(math.MinInt, -2), int64(-2))
 }
+
+func Test_min(t *testing.T) {
+	require.Equal(t, min(2, 1), int64(1))
+	require.Equal(t, min(1, 2), int64(1))
+	require.Equal(t, min(-2, 1), int64(-2))
+	require.Equal(t, min(1, -2), int64(-2))
+	require.Equal(t, min(math.MaxInt, -2), int64(-2))
+	require.Equal(t, min(math.MinInt, -2), int64(math.MinInt))
+}


### PR DESCRIPTION
[ITSE-68](https://itse.youtrack.cloud/issue/ITSE-68) This change attempts to make a more accurate count of instances required in a cluster by not including the last portion of memory and CPU in each instance. It assumes that if the smallest container can't fit then no other container can either.

_Note: this pull request also includes some refactoring, committed separately. It may be helpful to look separately at the commits with messages that do not start with "refactor:"._